### PR TITLE
Improve cleanup for VirtualHueDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,19 @@ requests.put(
 Hue2DMXBridgeDevice(dmx, bridge, "3", lambda r, g, b: {0: r, 1: g, 2: b})
 
 # Hue device
-hue = VirtualHueDevice(
+with VirtualHueDevice(
     bridge_ip="127.0.0.1:8000",
     auth_token="demo",
     device_id="1",
     scheme="https",
-)
-hue.set_state(on=True, brightness=50)
+) as hue:
+    hue.set_state(on=True, brightness=50)
 
-# send an Entertainment API update
-hue.set_state(on=True, brightness=80, xy=[0.5, 0.4], use_entertainment=True)
+    # send an Entertainment API update
+    hue.set_state(on=True, brightness=80, xy=[0.5, 0.4], use_entertainment=True)
 ```
 
 These classes are simplified and intended for testing or educational purposes.
 The optional Entertainment API support allows basic streaming of color updates
-for quick experiments without real Hue hardware.
+for quick experiments without real Hue hardware. When used as a context manager,
+`VirtualHueDevice` automatically closes its network socket on exit.

--- a/test_virtual_devices.py
+++ b/test_virtual_devices.py
@@ -197,3 +197,22 @@ def test_huestream_rate_limiting(monkeypatch):
     time.sleep(0.2)
     assert updates <= 6
 
+
+def test_hue_device_context_manager():
+    port = get_free_port()
+    bridge = VirtualHueBridge(port=port)
+    bridge.register_light("7")
+    bridge.start()
+    time.sleep(0.5)
+
+    with VirtualHueDevice(
+        bridge_ip=f"127.0.0.1:{port}",
+        auth_token="token",
+        device_id="7",
+        scheme="https",
+    ) as device:
+        resp = device.set_state(on=True, brightness=10)
+        assert resp.status_code == 200
+
+    assert device._sock.fileno() == -1
+

--- a/virtual_devices.py
+++ b/virtual_devices.py
@@ -155,6 +155,16 @@ class VirtualHueDevice:
         self._sock.sendto(msg, (host, udp_port))
         self._seq = (self._seq + 1) % 256
 
+    def close(self) -> None:
+        """Close the underlying UDP socket."""
+        self._sock.close()
+
+    def __enter__(self) -> "VirtualHueDevice":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
 
 class VirtualHueBridge:
     """Minimal virtual Hue Bridge implementing Hue API v2 endpoints."""


### PR DESCRIPTION
## Summary
- allow using `VirtualHueDevice` as a context manager
- update README with example and docs about the new capability
- close UDP socket automatically
- add regression test for context manager support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d32cb5eec8327a788e55c474d31e5