### PR TITLE
Add RGB to xy conversion helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains simple Python implementations of virtual lighting devic
 - `VirtualHueBridge` offers a lightweight Flask server that emulates some Hue Bridge v2 endpoints.
 - `Hue2DMXBridgeDevice` exposes a DMX device as a Hue lamp using a custom RGB-to-DMX mapping. Streaming updates are throttled to the DMX refresh rate (~44 Hz).
 - `xy_to_rgb(x, y, brightness)` converts Hue xy coordinates to an RGB tuple.
+- `rgb_to_xy(r, g, b)` converts an RGB tuple back to xy coordinates and brightness.
 
 ## Usage
 

--- a/test_virtual_devices.py
+++ b/test_virtual_devices.py
@@ -8,6 +8,8 @@ from virtual_devices import (
     VirtualHueDevice,
     VirtualHueBridge,
     Hue2DMXBridgeDevice,
+    rgb_to_xy,
+    xy_to_rgb,
 )
 from python_hue_v2 import bridge as hue_bridge
 
@@ -42,6 +44,20 @@ def test_dmx_device_address():
     assert dmx.address == 20
     with pytest.raises(ValueError):
         dmx.set_address(0)
+
+
+def test_rgb_xy_roundtrip():
+    samples = [
+        (0.3, 0.3, 50),
+        (0.1, 0.2, 75),
+        (0.7, 0.3, 100),
+    ]
+
+    for x, y, bri in samples:
+        r, g, b = xy_to_rgb(x, y, bri)
+        rx, ry, _ = rgb_to_xy(r, g, b)
+        assert pytest.approx(rx, abs=0.15) == x
+        assert pytest.approx(ry, abs=0.15) == y
 
 
 def test_hue_bridge_and_device():

--- a/virtual_devices.py
+++ b/virtual_devices.py
@@ -33,6 +33,37 @@ def xy_to_rgb(x: float, y: float, brightness: int) -> tuple[int, int, int]:
     return int(r * 255), int(g * 255), int(b * 255)
 
 
+def rgb_to_xy(r: int, g: int, b: int) -> tuple[float, float, int]:
+    """Convert an RGB tuple to CIE xy coordinates and brightness.
+
+    The returned brightness value is in the Hue 0-100 scale.
+    """
+    if r == 0 and g == 0 and b == 0:
+        return 0.0, 0.0, 0
+
+    R = r / 255.0
+    G = g / 255.0
+    B = b / 255.0
+
+    R = ((R + 0.055) / 1.055) ** 2.4 if R > 0.04045 else R / 12.92
+    G = ((G + 0.055) / 1.055) ** 2.4 if G > 0.04045 else G / 12.92
+    B = ((B + 0.055) / 1.055) ** 2.4 if B > 0.04045 else B / 12.92
+
+    X = R * 0.664511 + G * 0.154324 + B * 0.162028
+    Y = R * 0.283881 + G * 0.668433 + B * 0.047685
+    Z = R * 0.000088 + G * 0.072310 + B * 0.986039
+
+    xyz_sum = X + Y + Z
+    if xyz_sum == 0:
+        x = y = 0.0
+    else:
+        x = X / xyz_sum
+        y = Y / xyz_sum
+
+    brightness = max(r, g, b) * 100 // 255
+    return x, y, int(brightness)
+
+
 class VirtualDMXDevice:
     """Virtual representation of a DMX512 device with an assignable address."""
 


### PR DESCRIPTION
## Summary
- add `rgb_to_xy` to convert RGB values to xy coordinates
- document the new function in the README
- test roundtrip of `xy_to_rgb` and `rgb_to_xy`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d33c3447c8327a1751feaa8eab018